### PR TITLE
Investigate prod demo build issues

### DIFF
--- a/src/lib/demo/DemoConstants.ts
+++ b/src/lib/demo/DemoConstants.ts
@@ -173,5 +173,5 @@ export const bankSvg = `<svg class="bank-icon" width="48" height="48" viewBox="0
  * This ensures demo builds are separate deployments with no runtime activation.
  */
 export function checkIfDemoIsActive(): boolean {
-    return process.env.IS_DEMO_BUILD === 'true';
+    return !!(process.env as any).IS_DEMO_BUILD;
 }

--- a/src/lib/demo/DemoConstants.ts
+++ b/src/lib/demo/DemoConstants.ts
@@ -173,5 +173,5 @@ export const bankSvg = `<svg class="bank-icon" width="48" height="48" viewBox="0
  * This ensures demo builds are separate deployments with no runtime activation.
  */
 export function checkIfDemoIsActive(): boolean {
-    return true;
+    return process.env.IS_DEMO_BUILD === 'true';
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -60,7 +60,7 @@ function sri(asset) {
 process.env.VUE_APP_BITCOIN_JS_INTEGRITY_HASH = sri(fs.readFileSync(path.join(__dirname, 'public/bitcoin/BitcoinJS.min.js')));
 process.env.VUE_APP_COPYRIGHT_YEAR = new Date().getUTCFullYear().toString(); // year at build time
 
-console.log('Building for:', buildName, ', release:', `"wallet-${release}"`, buildName === 'demo' ? '(DEMO MODE)' : '');
+console.log('Building for:', buildName, ', release:', `"wallet-${release}"`, buildName.startsWith('demo') ? '(DEMO MODE)' : '');
 
 const configFileMap = {
     'local': 'config.local.ts',
@@ -107,7 +107,7 @@ module.exports = {
             new webpack.DefinePlugin({
                 'process.env.SENTRY_RELEASE': `"wallet-${release}"`,
                 'process.env.VERSION': `"${release}"`,
-                'process.env.IS_DEMO_BUILD': JSON.stringify(buildName === 'demo'),
+                'process.env.IS_DEMO_BUILD': JSON.stringify(buildName.startsWith('demo')),
             }),
             new webpack.ProvidePlugin({
                 Buffer: ['buffer', 'Buffer'],

--- a/vue.config.js
+++ b/vue.config.js
@@ -107,7 +107,7 @@ module.exports = {
             new webpack.DefinePlugin({
                 'process.env.SENTRY_RELEASE': `"wallet-${release}"`,
                 'process.env.VERSION': `"${release}"`,
-                'process.env.IS_DEMO_BUILD': JSON.stringify(buildName.startsWith('demo')),
+                'process.env.IS_DEMO_BUILD': buildName.startsWith('demo'),
             }),
             new webpack.ProvidePlugin({
                 Buffer: ['buffer', 'Buffer'],


### PR DESCRIPTION
Correctly activate demo mode for both `demo` and `demo-production` builds.

Previously, `checkIfDemoIsActive()` was hardcoded to `true`, always enabling demo mode. Additionally, the `vue.config.js` only checked for an exact `buildName === 'demo'`, failing to activate demo mode for `demo-production` builds. This PR updates `checkIfDemoIsActive()` to use the `IS_DEMO_BUILD` environment variable and modifies the webpack configuration to correctly identify any build starting with 'demo' as a demo build.

---
<a href="https://cursor.com/background-agent?bcId=bc-e833c22b-5684-4ea0-97ea-1438e7e8aa09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e833c22b-5684-4ea0-97ea-1438e7e8aa09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

